### PR TITLE
Move label to props with fallback to "Password"

### DIFF
--- a/src/component/passwordInput.js
+++ b/src/component/passwordInput.js
@@ -15,7 +15,8 @@ export default class PasswordInputText extends React.Component {
         
         this.state = {
             icEye: 'visibility-off',
-            password: true
+            password: true,
+            label: props.label
         }
     }
 
@@ -44,7 +45,7 @@ export default class PasswordInputText extends React.Component {
             <View>
                 <TextField {...this.props}
                            secureTextEntry={this.state.password}
-                           label="Password"/>
+                           label={this.state.label}/>
                 <Icon style={styles.icon}
                       name={this.state.icEye}
                       size={this.props.iconSize}
@@ -69,5 +70,6 @@ export const styles = StyleSheet.create({
 
 PasswordInputText.defaultProps = {
 iconSize:25,
+label: 'Password',
 }
     


### PR DESCRIPTION
Hard coding "Password" in label make it impossible to change it.

Instead of `Password` I might want something like `pin`

I think other people might also use the library to hide text where "Password" as a label won't be the best wording