### PR TITLE
Update passwordInput.js

### DIFF
--- a/src/component/passwordInput.js
+++ b/src/component/passwordInput.js
@@ -43,8 +43,7 @@ export default class PasswordInputText extends React.Component {
         return (
             <View>
                 <TextField {...this.props}
-                           secureTextEntry={this.state.password}
-                           label="Password"/>
+                           secureTextEntry={this.state.password}/>
                 <Icon style={styles.icon}
                       name={this.state.icEye}
                       size={this.props.iconSize}
@@ -69,5 +68,6 @@ export const styles = StyleSheet.create({
 
 PasswordInputText.defaultProps = {
 iconSize:25,
+label: 'Password',
 }
     


### PR DESCRIPTION
The old version enforces the use of the 'Password' label for the input

The edit is necessary for multiple language support